### PR TITLE
fix: proTable 支持 hideInTable 列，目前计算 tableWidth 没有剔除 hideInTable 列

### DIFF
--- a/src/useAntdResizableHeader.tsx
+++ b/src/useAntdResizableHeader.tsx
@@ -50,6 +50,7 @@ export type ColumnOriginType<T> = {
   children?: T[];
   resizable?: boolean;
   ellipsis?: any;
+  hideInTable?: boolean;
 };
 
 type CacheType = { width?: Width; index: number };
@@ -171,7 +172,9 @@ function useAntdResizableHeader<ColumnType extends ColumnOriginType<ColumnType> 
         if (cls[i].children) {
           loop(cls[i].children as ColumnType[]);
         } else {
-          width += Number(cls[i].width) || Number(columns?.[columns.length - 1].width) || defaultWidth;
+          if (cls[i].hideInTable === false) {
+            width += Number(cls[i].width) || Number(columns?.[columns.length - 1].width) || defaultWidth;
+          }
         }
       }
     })(resizableColumns);


### PR DESCRIPTION
tableWidth 计算时，没有剔除 hideInTable 列，导致如图：
![wecom-temp-8656e089a7e2bc8370a876e7e9667135](https://user-images.githubusercontent.com/5210208/168232561-ce6e1ba8-1d93-4958-9d43-e9be2f6641a0.png)
