### PR TITLE
fix: 可以自定义勾选表头时，cacheWidth失效

### DIFF
--- a/src/useAntdResizableHeader.tsx
+++ b/src/useAntdResizableHeader.tsx
@@ -99,12 +99,14 @@ function useAntdResizableHeader<ColumnType extends ColumnOriginType<ColumnType>>
     resetLocalColumns()
   })
 
+  let kvMap: Map<string | number, CacheType>
+
   const onMount = useCallback(
     (id?: string | number) => (width?: number) => {
       if (width) {
         setResizableColumns((t) => {
           const nextColumns = depthFirstSearch(t, (col) => col[GETKEY] === id && !!col.width, width)
-          const kvMap = new Map<string | number, CacheType>()
+          kvMap = kvMap || new Map<string | number, CacheType>()
           function dig(cols: ColumnType[]) {
             cols.forEach((col, i) => {
               const key = col[GETKEY]


### PR DESCRIPTION
![image](https://github.com/hemengke1997/use-antd-resizable-header/assets/20540004/00f8f259-6ddb-40d5-a588-01940eaf9202)

比如这种场景下，假设有a,b,c三个表头字段，勾选了a与b表头，拖拽a和b的宽度，然后取消勾选a与b，之后再次勾选a与b，会发现之前a拖拽宽度的还保留，但b之前拖拽的宽度消失变成了默认宽度。原因是当二次勾选a时使用的是之前拖拽过a与b宽度的kvMap所以a的宽度还保留，但onMount重新创建了kvMap导致二次勾选b时使用的的kvMap中不包含之前的b宽度。

所以是不是可以给kvMap留在useAntdResizableHeader的闭包内，这样缓存的宽度不会消失，同时每次调用useAntdResizableHeader也不会引起其他表格相同key的宽度